### PR TITLE
cm: Minor config reorganization

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -63,6 +63,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.build.selinux=1
 
+# Default notification/alarm sounds
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.config.notification_sound=Argon.ogg \
+    ro.config.alarm_alert=Helium.ogg
+
 ifneq ($(TARGET_BUILD_VARIANT),user)
 # Thank you, please drive thru!
 PRODUCT_PROPERTY_OVERRIDES += persist.sys.dun.override=0
@@ -123,6 +128,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     vendor/cm/config/permissions/com.cyanogenmod.android.xml:system/etc/permissions/com.cyanogenmod.android.xml
 
+# Include CM audio files
+include vendor/cm/config/cm_audio.mk
+
 # Theme engine
 include vendor/cm/config/themes_common.mk
 
@@ -141,7 +149,8 @@ PRODUCT_PACKAGES += \
 # Optional CM packages
 PRODUCT_PACKAGES += \
     libemoji \
-    Terminal
+    Terminal \
+    LiveWallpapersPicker
 
 # Include librsjni explicitly to workaround GMS issue
 PRODUCT_PACKAGES += \
@@ -163,7 +172,9 @@ PRODUCT_PACKAGES += \
     LiveLockScreenService \
     WeatherProvider \
     DataUsageProvider \
-    WallpaperPicker
+    WallpaperPicker \
+    SoundRecorder \
+    Screencast
 
 # Exchange support
 PRODUCT_PACKAGES += \
@@ -184,7 +195,18 @@ PRODUCT_PACKAGES += \
     oprofiled \
     sqlite3 \
     strace \
-    pigz
+    pigz \
+    7z \
+    lib7z \
+    bash \
+    bzip2 \
+    curl \
+    powertop \
+    unrar \
+    unzip \
+    vim \
+    wget \
+    zip
 
 # Custom off-mode charger
 ifneq ($(WITH_CM_CHARGER),false)

--- a/config/common_full.mk
+++ b/config/common_full.mk
@@ -3,36 +3,16 @@ $(call inherit-product, vendor/cm/config/common.mk)
 
 PRODUCT_SIZE := full
 
-# Include CM audio files
-include vendor/cm/config/cm_audio.mk
-
 # Optional CM packages
 PRODUCT_PACKAGES += \
     Galaxy4 \
     HoloSpiralWallpaper \
     LiveWallpapers \
-    LiveWallpapersPicker \
     MagicSmokeWallpapers \
     NoiseField \
     PhaseBeam \
     PhotoTable \
-    SoundRecorder \
-    PhotoPhase \
-    Screencast
-
-# Extra tools in CM
-PRODUCT_PACKAGES += \
-    7z \
-    lib7z \
-    bash \
-    bzip2 \
-    curl \
-    powertop \
-    unrar \
-    unzip \
-    vim \
-    wget \
-    zip
+    PhotoPhase
 
 # Themes
 PRODUCT_PACKAGES += \

--- a/config/common_full_phone.mk
+++ b/config/common_full_phone.mk
@@ -8,11 +8,6 @@ PRODUCT_PACKAGES += \
 # Include CM LatinIME dictionaries
 PRODUCT_PACKAGE_OVERLAYS += vendor/cm/overlay/dictionaries
 
-# Default notification/alarm sounds
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.config.notification_sound=Argon.ogg \
-    ro.config.alarm_alert=Helium.ogg
-
 ifeq ($(TARGET_SCREEN_WIDTH) $(TARGET_SCREEN_HEIGHT),$(space))
     PRODUCT_COPY_FILES += \
         vendor/cm/prebuilt/common/bootanimation/480.zip:system/media/bootanimation.zip

--- a/config/common_full_tablet_wifionly.mk
+++ b/config/common_full_tablet_wifionly.mk
@@ -8,11 +8,6 @@ PRODUCT_PACKAGES += \
 # Include CM LatinIME dictionaries
 PRODUCT_PACKAGE_OVERLAYS += vendor/cm/overlay/dictionaries
 
-# Default notification/alarm sounds
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.config.notification_sound=Argon.ogg \
-    ro.config.alarm_alert=Helium.ogg
-
 ifeq ($(TARGET_SCREEN_WIDTH) $(TARGET_SCREEN_HEIGHT),$(space))
     PRODUCT_COPY_FILES += \
         vendor/cm/prebuilt/common/bootanimation/800.zip:system/media/bootanimation.zip

--- a/config/common_full_tv.mk
+++ b/config/common_full_tv.mk
@@ -1,11 +1,6 @@
 # Inherit common CM stuff
 $(call inherit-product, vendor/cm/config/common_full.mk)
 
-# Default notification/alarm sounds
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.config.notification_sound=Argon.ogg \
-    ro.config.alarm_alert=Helium.ogg
-
 ifeq ($(TARGET_SCREEN_WIDTH) $(TARGET_SCREEN_HEIGHT),$(space))
     PRODUCT_COPY_FILES += \
         vendor/cm/prebuilt/common/bootanimation/800.zip:system/media/bootanimation.zip

--- a/config/common_mini.mk
+++ b/config/common_mini.mk
@@ -2,12 +2,3 @@
 $(call inherit-product, vendor/cm/config/common.mk)
 
 PRODUCT_SIZE := mini
-
-# Include CM audio files
-include vendor/cm/config/cm_audio.mk
-
-# Default notification/alarm sounds
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.config.notification_sound=Argon.ogg \
-    ro.config.alarm_alert=Helium.ogg
-


### PR DESCRIPTION
- Move extra tools to common.mk. These are needed for CMFM, and should
  be included for all.
- Move LiveWallpapersPicker, SoundRecorder and Screencast
  to common.mk. These apps are extremely small, and only takes up
  less than 1 MB combined.
- Move sound property overrides to common.mk. There's no need
  to have them spread across several files.
- Include CM audio files from common.mk

Change-Id: If308506cd9cd0a75014de988c242d700db5d16f3
